### PR TITLE
Feat key hand over

### DIFF
--- a/app/Enums/KeyStatus.php
+++ b/app/Enums/KeyStatus.php
@@ -2,14 +2,13 @@
 
 namespace App\Enums;
 
-enum ContractStatus: string
+enum KeyStatus: string
 {
     // --- 1. Definisi Kasus ---
-    case PENDING_PAYMENT = 'pending_payment';
-    case ACTIVE = 'active';
-    case EXPIRED = 'expired';
-    case CANCELLED = 'cancelled';
-    case TERMINATED = 'terminated';
+    case PENDING_HANDOVER = 'pending_handover';
+    case HANDED_OVER = 'handed_over';
+    case RETURNED = 'returned';
+    case LOST = 'lost';
 
     /**
      * Mengembalikan semua nilai 'value' dari enum.
@@ -26,11 +25,10 @@ enum ContractStatus: string
     {
         // --- 2. Label untuk Setiap Status ---
         return match ($this) {
-            self::PENDING_PAYMENT => 'Menunggu Pembayaran',
-            self::ACTIVE => 'Aktif',
-            self::EXPIRED => 'Kedaluwarsa',
-            self::CANCELLED => 'Dibatalkan',
-            self::TERMINATED => 'Dihentikan',
+            self::PENDING_HANDOVER => 'Belum Diserahkan',
+            self::HANDED_OVER      => 'Sudah Diserahkan',
+            self::RETURNED         => 'Sudah Dikembalikan',
+            self::LOST             => 'Hilang',
         };
     }
 
@@ -54,11 +52,10 @@ enum ContractStatus: string
     {
         // --- 3. Warna untuk Setiap Status ---
         return match ($this) {
-            self::PENDING_PAYMENT => ['bg-yellow-100', 'text-yellow-800', 'dark:bg-yellow-900/30', 'dark:text-yellow-400'],
-            self::ACTIVE => ['bg-green-100', 'text-green-800', 'dark:bg-green-900/30', 'dark:text-green-400'],
-            self::EXPIRED => ['bg-gray-100', 'text-gray-800', 'dark:bg-gray-900/30', 'dark:text-gray-400'],
-            self::CANCELLED => ['bg-orange-100', 'text-orange-800', 'dark:bg-orange-900/30', 'dark:text-orange-400'],
-            self::TERMINATED => ['bg-red-100', 'text-red-800', 'dark:bg-red-900/30', 'dark:text-red-400'],
+            self::PENDING_HANDOVER => ['bg-yellow-100', 'text-yellow-800', 'dark:bg-yellow-900/30', 'dark:text-yellow-400'], // Kuning untuk status menunggu
+            self::HANDED_OVER      => ['bg-green-100', 'text-green-800', 'dark:bg-green-900/30', 'dark:text-green-400'],   // Hijau untuk status sukses/aktif
+            self::RETURNED         => ['bg-blue-100', 'text-blue-800', 'dark:bg-blue-900/30', 'dark:text-blue-400'],     // Biru untuk status selesai/netral
+            self::LOST             => ['bg-red-100', 'text-red-800', 'dark:bg-red-900/30', 'dark:text-red-400'],         // Merah untuk status masalah/hilang
         };
     }
 

--- a/app/Livewire/Frontend/Tenancy/TenancyForm.php
+++ b/app/Livewire/Frontend/Tenancy/TenancyForm.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Frontend\Tenancy;
 use App\Enums\ContractStatus;
 use App\Enums\GenderAllowed;
 use App\Enums\InvoiceStatus;
+use App\Enums\KeyStatus;
 use App\Enums\OccupantStatus;
 use App\Jobs\SendWelcomeEmail;
 use App\Models\Contract;
@@ -307,6 +308,7 @@ class TenancyForm extends Component
                 'end_date' => $this->endDate,
                 'pricing_basis' => $this->pricingBasis->value,
                 'total_price' => $this->totalPrice,
+                'key_status' => KeyStatus::PENDING_HANDOVER,
                 'status' => ContractStatus::PENDING_PAYMENT,
             ]);
 

--- a/app/Livewire/Managers/Contract.php
+++ b/app/Livewire/Managers/Contract.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Managers;
 
 use App\Enums\ContractStatus;
+use App\Enums\KeyStatus;
 use App\Enums\PricingBasis;
 use App\Models\Contract as ContractModel;
 use App\Models\Occupant;
@@ -29,11 +30,13 @@ class Contract extends Component
         $startDate = '',
         $endDate = '',
         $pricingBasis = '',
+        $keyStatus = '',
         $status = '';
 
     // Opsi dropdown
     public
         $statusOptions,
+        $keyStatusOptions,
         $unitOptions,
         $occupantOptions,
         $occupantTypeOptions,
@@ -65,6 +68,7 @@ class Contract extends Component
     public function mount()
     {
         $this->statusOptions = ContractStatus::options();
+        $this->keyStatusOptions = KeyStatus::options(); 
         $this->pricingBasisOptions = PricingBasis::options();
         $this->occupantTypeOptions = OccupantType::query()
             ->get()
@@ -160,6 +164,7 @@ class Contract extends Component
         $this->startDate = $contract->start_date ? $contract->start_date->format('Y-m-d') : null;
         $this->endDate = $contract->end_date ? $contract->end_date->format('Y-m-d') : null;
         $this->pricingBasis = $contract->pricing_basis->value;
+        $this->keyStatus = $contract->key_status->value;
         $this->status = $contract->status->value;
     }
 
@@ -176,6 +181,7 @@ class Contract extends Component
             'endDate' => 'required|date|after_or_equal:startDate',
             'pricingBasis' => ['required', \Illuminate\Validation\Rule::in(PricingBasis::values())],
             'status' => ['required', \Illuminate\Validation\Rule::in(ContractStatus::values())],
+            'keyStatus' => ['nullable', \Illuminate\Validation\Rule::in(KeyStatus::values())],
         ];
     }
 
@@ -203,6 +209,8 @@ class Contract extends Component
             'pricingBasis.in' => 'Dasar harga yang dipilih tidak valid.',
             'status.required' => 'Status kontrak wajib diisi.',
             'status.in' => 'Status kontrak yang dipilih tidak valid.',
+            'keyStatus.in' => 'Status kunci yang dipilih tidak valid.',
+            'keyStatus.nullable' => 'Status kunci bersifat opsional.',
         ];
     }
 
@@ -217,6 +225,10 @@ class Contract extends Component
     {
         $this->validate($this->rules());
 
+        if ($this->contractCode === '') {
+            $this->contractCode = ContractModel::generateAutoContractCode();
+        }
+
         $data = [
             'contract_code' => $this->contractCode,
             'unit_id' => $this->unitId,
@@ -225,6 +237,7 @@ class Contract extends Component
             'start_date' => $this->startDate,
             'end_date' => $this->endDate,
             'pricing_basis' => $this->pricingBasis,
+            'key_status' => $this->keyStatus,
             'status' => $this->status,
         ];
 
@@ -255,6 +268,7 @@ class Contract extends Component
             'endDate',
             'pricingBasis',
             'status',
+            'keyStatus',
         ]);
         $this->contractIdBeingSelected = null;
         $this->showModal = false;

--- a/app/Models/Contract.php
+++ b/app/Models/Contract.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\ContractStatus;
 use App\Enums\KeyStatus;
 use App\Enums\PricingBasis;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Str;
@@ -25,8 +26,8 @@ class Contract extends Model implements Authenticatable
         'pricing_basis',
         'total_price',
         'expired_date',
-        'status',
         'key_status',
+        'status',
     ];
 
     protected $casts = [
@@ -34,8 +35,8 @@ class Contract extends Model implements Authenticatable
         'end_date' => 'datetime',
         'expired_date' => 'datetime',
         'pricing_basis' => PricingBasis::class,
-        'status' => ContractStatus::class,
         'key_status' => KeyStatus::class,
+        'status' => ContractStatus::class,
     ];
 
     public function unit()
@@ -80,6 +81,17 @@ class Contract extends Model implements Authenticatable
         $parts = explode('_', $pricingBasis);
         $basisChar = isset($parts[1]) ? substr($parts[1], 0, 1) : 'X';
         $prefix = strtoupper($clusterChar . $typeChar . $basisChar);
+        do {
+            $randomPart = strtoupper(Str::random(5));
+            $generatedCode = $prefix . $randomPart;
+        } while (self::where('contract_code', $generatedCode)->exists());
+
+        return $generatedCode;
+    }
+
+    public static function generateAutoContractCode()
+    {
+        $prefix = strtoupper(Carbon::now()->format('D'));
         do {
             $randomPart = strtoupper(Str::random(5));
             $generatedCode = $prefix . $randomPart;

--- a/app/Models/Contract.php
+++ b/app/Models/Contract.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\ContractStatus;
+use App\Enums\KeyStatus;
 use App\Enums\PricingBasis;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -25,6 +26,7 @@ class Contract extends Model implements Authenticatable
         'total_price',
         'expired_date',
         'status',
+        'key_status',
     ];
 
     protected $casts = [
@@ -33,6 +35,7 @@ class Contract extends Model implements Authenticatable
         'expired_date' => 'datetime',
         'pricing_basis' => PricingBasis::class,
         'status' => ContractStatus::class,
+        'key_status' => KeyStatus::class,
     ];
 
     public function unit()

--- a/database/migrations/2025_07_12_013537_create_contracts_table.php
+++ b/database/migrations/2025_07_12_013537_create_contracts_table.php
@@ -26,11 +26,19 @@ return new class extends Migration
 
             $table->timestamp('expired_date')->nullable();
 
+            $table->enum('key_status', [
+               'pending_handover',
+               'handed_over',
+               'returned',
+               'lost',
+           ])->nullable();
+
             $table->enum('status', [
                 'pending_payment',
                 'active',
                 'expired',
                 'cancelled',
+                'terminated',
             ])->default('pending_payment');
 
             $table->timestamps();

--- a/database/seeders/ContractSeeder.php
+++ b/database/seeders/ContractSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Enums\KeyStatus;
 use Illuminate\Database\Seeder;
 use App\Models\Contract;
 use App\Models\Unit;
@@ -44,6 +45,7 @@ class ContractSeeder extends Seeder
                 'total_price' => fake()->numberBetween(500000, 2000000),
                 'status' => fake()->randomElement([ContractStatus::PENDING_PAYMENT, ContractStatus::ACTIVE]),
                 'expired_date' => $endDate->copy()->addHours(config('tenancy.initial_payment_due_hours', 2)),
+                'key_status' => KeyStatus::PENDING_HANDOVER,
             ]);
 
             // Tandai unit sebagai tidak tersedia untuk mencegah duplikasi

--- a/resources/views/livewire/contracts/dashboard/contract-partials/_occupant.blade.php
+++ b/resources/views/livewire/contracts/dashboard/contract-partials/_occupant.blade.php
@@ -49,9 +49,18 @@
                 <p class="font-semibold">{{ $contract->start_date->format('d M Y') }} -
                     {{ $contract->end_date->format('d M Y') }}</p>
             </div>
-            <div>
-                <p class="text-sm text-gray-500">Tipe Sewa</p>
-                <p class="font-semibold">{{ $contract->pricing_basis->label() }}</p>
+            <div class="flex items-center gap-4">
+                <div>
+                    <p class="text-sm text-gray-500">Tipe Sewa</p>
+                    <p class="font-semibold">{{ $contract->pricing_basis->label() }}
+                </div>
+                <div>
+                    <p class="text-sm text-gray-500">Kunci</p>
+                    <x-managers.ui.badge class="{{ implode(' ', $contract->key_status->color()) }}">
+                        {{ $contract->key_status->label() }}
+                    </x-managers.ui.badge></p>
+                </div>
+
             </div>
             <div class="border-t dark:border-zinc-600 pt-4">
                 <div class="grid gap-4">

--- a/resources/views/livewire/managers/tenancy/contracts/partials/_data-table.blade.php
+++ b/resources/views/livewire/managers/tenancy/contracts/partials/_data-table.blade.php
@@ -1,5 +1,14 @@
 <x-managers.ui.card class="p-0">
-    <x-managers.table.table :headers="['Kode Kontrak', 'Penyewa Utama', 'Unit', 'Total Harga', 'Jangka Waktu', 'Status', 'Aksi']">
+    <x-managers.table.table :headers="[
+        'Kode Kontrak',
+        'Penyewa Utama',
+        'Unit',
+        'Total Harga',
+        'Jangka Waktu',
+        'Status Kunci',
+        'Status',
+        'Aksi',
+    ]">
         <x-managers.table.body>
             @forelse ($contracts as $contract)
                 <x-managers.table.row wire:key="{{ $contract->id }}">
@@ -46,6 +55,13 @@
                             {{ $contract->start_date->translatedFormat('d M Y') }} -
                             {{ $contract->end_date->translatedFormat('d M Y') }}
                         </span>
+                    </x-managers.table.cell>
+
+                    {{-- Key Status --}}
+                    <x-managers.table.cell>
+                        <x-managers.ui.badge :color="$contract->key_status->color()">
+                            {{ $contract->key_status->label() }}
+                        </x-managers.ui.badge>
                     </x-managers.table.cell>
 
                     {{-- Status --}}

--- a/resources/views/livewire/managers/tenancy/contracts/partials/_modal-form.blade.php
+++ b/resources/views/livewire/managers/tenancy/contracts/partials/_modal-form.blade.php
@@ -50,13 +50,20 @@
         {{-- Dasar Harga --}}
         <div>
             <x-managers.form.label>Dasar Harga</x-managers.form.label>
-            <x-managers.form.select wire:model="pricingBasis" :options="$pricingBasisOptions" label="Pilih Dasar Harga" required />
+            <x-managers.form.select wire:model="pricingBasis" rupiah :options="$pricingBasisOptions" label="Pilih Dasar Harga"
+                required />
         </div>
 
         {{-- Status Kontrak --}}
         <div>
             <x-managers.form.label>Status Kontrak</x-managers.form.label>
             <x-managers.form.select wire:model="status" :options="$statusOptions" label="Pilih Status" required />
+        </div>
+
+        {{-- Status Kunci --}}
+        <div>
+            <x-managers.form.label>Status Kunci</x-managers.form.label>
+            <x-managers.form.select wire:model="keyStatus" :options="$keyStatusOptions" label="Pilih Status Kunci" />
         </div>
 
         <div class="flex justify-end gap-2 pt-4">


### PR DESCRIPTION
This pull request introduces two major updates to the codebase: enhancements to the `ContractStatus` enum and the addition of a new `KeyStatus` enum. These changes improve the handling of contract and key statuses, including their labels, colors, and integration across various components. The updates also include modifications to database migrations, models, Livewire components, and Blade templates to support these new features.

### Enhancements to `ContractStatus` Enum:
- Added a new `TERMINATED` status to `ContractStatus`, along with its label ("Dihentikan") and color configuration (`bg-red-100`, `text-red-800`, etc.) for Tailwind CSS styling. [[1]](diffhunk://#diff-40f9bfa0aea5c6ce828078d4300c38f5210248a9f039c5c818f06fa0de3bc9e0R12) [[2]](diffhunk://#diff-40f9bfa0aea5c6ce828078d4300c38f5210248a9f039c5c818f06fa0de3bc9e0R33) [[3]](diffhunk://#diff-40f9bfa0aea5c6ce828078d4300c38f5210248a9f039c5c818f06fa0de3bc9e0L58-R61)

### Addition of `KeyStatus` Enum:
- Introduced the `KeyStatus` enum with cases like `PENDING_HANDOVER`, `HANDED_OVER`, `RETURNED`, and `LOST`, each with corresponding labels and Tailwind CSS color configurations. Helper methods for dropdown options and value parsing were also added.

### Integration of `KeyStatus` into Livewire Components:
- Updated `app/Livewire/Frontend/Tenancy/TenancyForm.php` to set the initial key status as `PENDING_HANDOVER` during contract creation.
- Modified `app/Livewire/Managers/Contract.php` to include `keyStatus` in form data, validation rules, dropdown options, and the `save()` method. [[1]](diffhunk://#diff-11487be844d7b763dd925971693513f5ef668ca2be3ef9377d9bbd2f51ec402eR33-R39) [[2]](diffhunk://#diff-11487be844d7b763dd925971693513f5ef668ca2be3ef9377d9bbd2f51ec402eR71) [[3]](diffhunk://#diff-11487be844d7b763dd925971693513f5ef668ca2be3ef9377d9bbd2f51ec402eR167) [[4]](diffhunk://#diff-11487be844d7b763dd925971693513f5ef668ca2be3ef9377d9bbd2f51ec402eR184) F0ac5de7L217R237, [[5]](diffhunk://#diff-11487be844d7b763dd925971693513f5ef668ca2be3ef9377d9bbd2f51ec402eR271)

### Database Updates:
- Added a `key_status` column to the `contracts` table with enum values matching the `KeyStatus` cases. The `TERMINATED` status was also added to the `status` column.

### UI Enhancements in Blade Templates:
- Updated `resources/views/livewire/contracts/dashboard/contract-partials/_occupant.blade.php` to display the key status badge alongside other contract details.
- Modified `resources/views/livewire/managers/tenancy/contracts/partials/_data-table.blade.php` to include a column for key status in the contract table. [[1]](diffhunk://#diff-fa2e377fc009daf71857b2be245baf67d517f0eb24bea3df1da9087fa268a8b1L2-R11) [[2]](diffhunk://#diff-fa2e377fc009daf71857b2be245baf67d517f0eb24bea3df1da9087fa268a8b1R60-R66)
- Added a dropdown for selecting key status in the contract modal form (`_modal-form.blade.php`).

These changes collectively enhance the management of contracts and keys, providing better visibility and control over their statuses.